### PR TITLE
Add University Controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityController.java
@@ -1,9 +1,42 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
+import edu.ucsb.cs156.spring.backenddemo.services.UniversityQueryService;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name="University info from http://universities.hipolabs.com/")
+@Slf4j
 @RestController
+@RequestMapping("/api/universities")
 public class UniversityController {
-    
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    UniversityQueryService universityQueryService;
+
+    @Operation(summary="Get universities and their basic information")
+    @GetMapping("/get")
+    public ResponseEntity<String> getCountryCodes(
+        @Parameter(name="name", example="Stanford") @RequestParam String name
+    ) throws JsonProcessingException {
+        log.info("getUniversityName: name={}", name);
+        String result = universityQueryService.getJSON(name);
+        return ResponseEntity.ok().body(result);
+    }
+
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryService.java
@@ -24,7 +24,7 @@ public class UniversityQueryService {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = "http://universities.hipolabs.com/search?name={name}";
 
     public String getJSON(String name) throws HttpClientErrorException {
        return "";

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryService.java
@@ -8,8 +8,15 @@ import org.springframework.web.client.RestTemplate;
 
 import lombok.extern.slf4j.Slf4j;
 
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import java.util.List;
+import java.util.Map;
 
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
@@ -27,6 +34,18 @@ public class UniversityQueryService {
     public static final String ENDPOINT = "http://universities.hipolabs.com/search?name={name}";
 
     public String getJSON(String name) throws HttpClientErrorException {
-       return "";
+        log.info("name={}", name);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, String> uriVariables = Map.of("name", name);
+
+        HttpEntity<String> entity = new HttpEntity<>("body", headers);
+
+        ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
+                uriVariables);
+
+        return re.getBody();
     }
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryService.java
@@ -1,9 +1,5 @@
 package edu.ucsb.cs156.spring.backenddemo.services;
 
-
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.springframework.web.client.RestTemplate;
 
 import lombok.extern.slf4j.Slf4j;

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityControllerTests.java
@@ -1,0 +1,45 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.UniversityQueryService;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+@WebMvcTest(value = UniversityController.class)
+public class UniversityControllerTests {
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  UniversityQueryService mockUniversityQueryService;
+
+
+  @Test
+  public void test_getUniversity() throws Exception {
+  
+    String fakeJsonResult="{ \"fake\" : \"result\" }";
+    String name = "Stanford";
+    when(mockUniversityQueryService.getJSON(eq(name))).thenReturn(fakeJsonResult);
+
+    String url = String.format("/api/universities/get?name=%s", name);
+
+    MvcResult response = mockMvc
+        .perform( get(url).contentType("application/json"))
+        .andExpect(status().isOk()).andReturn();
+
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(fakeJsonResult, responseString);
+  }
+
+}

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryServiceTests.java
@@ -1,0 +1,41 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+
+@RestClientTest(UniversityQueryService.class)
+public class UniversityQueryServiceTests {
+
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private UniversityQueryService universityQueryService;
+
+    @Test
+    public void test_getJSON() {
+
+        //Start here
+        String name = "Oxnard";
+        String expectedURL = UniversityQueryService.ENDPOINT.replace("{name}", name);
+
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = universityQueryService.getJSON(name);
+        assertEquals(fakeJsonResult, actualResult);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryServiceTests.java
@@ -25,7 +25,7 @@ public class UniversityQueryServiceTests {
     public void test_getJSON() {
 
         //Start here
-        String name = "Oxnard";
+        String name = "Stanford";
         String expectedURL = UniversityQueryService.ENDPOINT.replace("{name}", name);
 
         String fakeJsonResult = "{ \"fake\" : \"result\" }";


### PR DESCRIPTION
In this PR, we add an endpoint /api/universities/get that can be used to get information on universities of a given name.

Dev deployment: http://team01-rytuose-dev.dokku-15.cs.ucsb.edu/

Closes #15